### PR TITLE
Fix: Results page not displaying due to inline style

### DIFF
--- a/result.html
+++ b/result.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <div class="container">
-        <div id="resultArea" style="visibility: hidden;"> <!-- Initially hidden, made visible by script -->
+        <div id="resultArea"> <!-- Initially hidden, made visible by script -->
             <h2>診断結果</h2>
 
             <div class="result-section">


### PR DESCRIPTION
The resultArea div in result.html had an inline style 'visibility: hidden;' which prevented it from becoming visible even when the '.visible' class was added by script.js. This class primarily handles opacity and transform for a fade-in effect.

This commit removes the inline 'visibility: hidden;' style, allowing the existing CSS for opacity and transform transitions to correctly show the results content. The initial hidden state is now managed by 'opacity: 0;' in the stylesheet, which was already in place.